### PR TITLE
fix to reset start time for each day

### DIFF
--- a/stimulus/stimulus.py
+++ b/stimulus/stimulus.py
@@ -286,7 +286,7 @@ def simulate_days_alt(projected_volume_df, vol_dim, day_of_week_dist, day_start_
                          dials_per_reservation=dials_per_reservation,
                          reservation_length=reservation_length)
 
-        simulated_day = simulate_day(day_obj, abandon_dist)
+        simulated_day = simulate_day(day_object, abandon_dist)
         simulated_days.append(simulated_day)
     
     return simulated_days

--- a/stimulus/stimulus.py
+++ b/stimulus/stimulus.py
@@ -253,7 +253,7 @@ def simulate_days(day_list, abandon_dist, skip_sleep=True, fast_mode=True, verbo
         day = simulate_day(day, abandon_dist, skip_sleep, fast_mode, verbose_mode)
     return day_list
 
-def simulate_days_alt(projected_volume_df, vol_dim, day_of_week_dist, start_time, handles_base, 
+def simulate_days_alt(projected_volume_df, vol_dim, day_of_week_dist, day_start_time, handles_base,
                       agent_list, abandon_dist, outbound_list=[], outbound_reservation=0.0,
                       dials_per_reservation=0.0, reservation_length=0,
                       skip_sleep=True, fast_mode=True, verbose_mode=False):
@@ -264,6 +264,8 @@ def simulate_days_alt(projected_volume_df, vol_dim, day_of_week_dist, start_time
         count_calls = day[vol_dim]
         arrival_rates = count_calls * day_of_week_dist
         arrival_times = []
+
+        start_time = day_start_time
 
         for x in arrival_rates:
             for xx in range(start_time, start_time + 900):


### PR DESCRIPTION
the start_time variable kept growing up and wasn't being reset for each new day, hence the arrival times being assigned to day 2 calls were 24h+, and went up by another 24h for each following day.